### PR TITLE
Refactor auth flow with LoginForm and Dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,0 +1,13 @@
+import { authClient } from '../auth-client'
+
+export default function Dashboard() {
+  const { data: session } = authClient.useSession()
+  if (!session?.user) return null
+  return (
+    <div className="space-y-2">
+      <h2 className="text-lg font-semibold">Welcome</h2>
+      <p className="text-sm text-gray-500">{session.user.email}</p>
+      <div className="border p-4 rounded">Protected content coming soon.</div>
+    </div>
+  )
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { Button } from './ui/button'
+import { authClient } from '../auth-client'
+
+export default function LoginForm() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+  const sendLink = async () => {
+    if (!email) return
+    setLoading(true)
+    await authClient.signIn.magicLink({ email })
+    setLoading(false)
+    setSent(true)
+  }
+  if (sent) return <p className="p-2">Check your email to log in.</p>
+  return (
+    <div className="space-y-2 max-w-sm">
+      <input
+        className="border p-2 w-full"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <Button onClick={sendLink} disabled={loading}>
+        {loading ? 'Sending...' : 'Send Magic Link'}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -2,15 +2,22 @@ import { ReactNode } from 'react'
 import { Button } from './ui/button'
 import { authClient } from '../auth-client'
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default function Layout({
+  children,
+  showHeader = true,
+}: {
+  children: ReactNode
+  showHeader?: boolean
+}) {
+  const { data: session } = authClient.useSession()
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="border-b p-4 flex justify-between">
-        <h1 className="font-bold">Bun App</h1>
-        <nav>
+      {showHeader && session?.user && (
+        <header className="border-b p-4 flex justify-between">
+          <h1 className="font-bold">Bun App</h1>
           <Button onClick={() => authClient.signOut()}>Logout</Button>
-        </nav>
-      </header>
+        </header>
+      )}
       <main className="flex-1 p-4">{children}</main>
     </div>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,30 +1,13 @@
-import { useState } from 'react'
-import { Button } from '../components/ui/button'
 import Layout from '../components/layout'
+import LoginForm from '../components/LoginForm'
+import Dashboard from '../components/Dashboard'
 import { authClient } from '../auth-client'
 
 export default function Home() {
   const { data: session } = authClient.useSession()
-  const [email, setEmail] = useState('')
-
-  const requestMagic = async () => {
-    await authClient.signIn.magicLink({ email })
-    alert('Check your email for the magic link')
-  }
-
   return (
-    <Layout>
-      {session?.user ? (
-        <div>
-          <p>Signed in as {session.user.email}</p>
-          <Button onClick={() => authClient.signOut()}>Sign out</Button>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <input value={email} onChange={e => setEmail(e.target.value)} className="border p-2" placeholder="Email" />
-          <Button onClick={requestMagic}>Send Magic Link</Button>
-        </div>
-      )}
+    <Layout showHeader={!!session?.user}>
+      {session?.user ? <Dashboard /> : <LoginForm />}
     </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- move login UI to `LoginForm` component
- create minimal `Dashboard` component for authenticated users
- update `layout` with optional header
- simplify `Home` page logic

## Testing
- `bun run build.ts` *(fails: Could not resolve module 'react-dom/client')*

------
https://chatgpt.com/codex/tasks/task_e_68532d5b8930832f86a90a6668fc03d8