### PR TITLE
Add sidebar navigation component

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,0 +1,31 @@
+import { authClient } from '../auth-client'
+import { Button } from './ui/button'
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarTrigger,
+} from './ui/sidebar'
+
+export default function AppSidebar() {
+  const { data: session } = authClient.useSession()
+  if (!session?.user) return null
+  return (
+    <Sidebar>
+      <SidebarHeader>
+        <span className="font-bold flex-1">Bun App</span>
+        <span className="text-xs text-gray-500">{session.user.email}</span>
+        <SidebarTrigger />
+      </SidebarHeader>
+      <SidebarContent>
+        <a href="/" className="block px-3 py-2 rounded hover:bg-muted">Dashboard</a>
+        <a href="#" className="block px-3 py-2 rounded hover:bg-muted">Settings</a>
+        <a href="#" className="block px-3 py-2 rounded hover:bg-muted">Help</a>
+      </SidebarContent>
+      <SidebarFooter>
+        <Button size="sm" onClick={() => authClient.signOut()}>Logout</Button>
+      </SidebarFooter>
+    </Sidebar>
+  )
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
-import { Button } from './ui/button'
 import { authClient } from '../auth-client'
+import AppSidebar from './AppSidebar'
+import { SidebarProvider, SidebarTrigger } from './ui/sidebar'
 
 export default function Layout({
   children,
@@ -11,14 +12,18 @@ export default function Layout({
 }) {
   const { data: session } = authClient.useSession()
   return (
-    <div className="min-h-screen flex flex-col">
-      {showHeader && session?.user && (
-        <header className="border-b p-4 flex justify-between">
-          <h1 className="font-bold">Bun App</h1>
-          <Button onClick={() => authClient.signOut()}>Logout</Button>
-        </header>
-      )}
-      <main className="flex-1 p-4">{children}</main>
-    </div>
+    <SidebarProvider>
+      <div className="min-h-screen flex">
+        {session?.user && <AppSidebar />}
+        <div className="flex-1 flex flex-col">
+          {showHeader && session?.user && (
+            <header className="md:hidden border-b p-4 flex justify-between">
+              <SidebarTrigger />
+            </header>
+          )}
+          <main className="flex-1 p-4">{children}</main>
+        </div>
+      </div>
+    </SidebarProvider>
   )
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+const COOKIE = 'sidebar_open'
+function readCookie() {
+  const match = document.cookie.split('; ').find(c => c.startsWith(COOKIE + '='))
+  return match ? match.split('=')[1] === 'true' : true
+}
+
+interface SidebarCtx { open: boolean; setOpen: (v: boolean | ((v: boolean) => boolean)) => void }
+const SidebarContext = createContext<SidebarCtx | null>(null)
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true)
+  useEffect(() => { setOpen(readCookie()) }, [])
+  useEffect(() => {
+    document.cookie = `${COOKIE}=${open}; path=/; max-age=${60 * 60 * 24 * 7}`
+  }, [open])
+  return <SidebarContext.Provider value={{ open, setOpen }}>{children}</SidebarContext.Provider>
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext)
+  if (!ctx) throw new Error('SidebarProvider missing')
+  return ctx
+}
+
+export function Sidebar({ children }: { children: ReactNode }) {
+  const { open } = useSidebar()
+  return (
+    <aside className={`fixed md:static inset-y-0 left-0 w-64 bg-white border-r transform transition-transform flex flex-col ${open ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>{children}</aside>
+  )
+}
+
+export function SidebarHeader({ children }: { children: ReactNode }) {
+  return <div className="p-4 border-b flex items-center gap-2">{children}</div>
+}
+
+export function SidebarContent({ children }: { children: ReactNode }) {
+  return <div className="flex-1 overflow-y-auto p-4 space-y-2">{children}</div>
+}
+
+export function SidebarFooter({ children }: { children: ReactNode }) {
+  return <div className="p-4 border-t">{children}</div>
+}
+
+export function SidebarTrigger() {
+  const { setOpen } = useSidebar()
+  return (
+    <button onClick={() => setOpen(o => !o)} className="p-2 md:hidden border rounded">
+      ☰
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- add shadcn style sidebar utilities
- create `AppSidebar` with nav items and logout
- wrap layout with `SidebarProvider`

## Testing
- `bun run build.ts`

------
https://chatgpt.com/codex/tasks/task_e_685332734898832f978d478320e96906