### PR TITLE
Fix sidebar toggle visibility on desktop

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -27,7 +27,15 @@ export function useSidebar() {
 export function Sidebar({ children }: { children: ReactNode }) {
   const { open } = useSidebar()
   return (
-    <aside className={`fixed md:static inset-y-0 left-0 w-64 bg-white border-r transform transition-transform flex flex-col ${open ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>{children}</aside>
+    <aside
+      className={`fixed md:static inset-y-0 left-0 bg-white border-r transform transition-all flex flex-col ${
+        open
+          ? 'w-64 translate-x-0'
+          : 'w-0 md:w-16 -translate-x-full md:translate-x-0'
+      }`}
+    >
+      {children}
+    </aside>
   )
 }
 
@@ -46,7 +54,10 @@ export function SidebarFooter({ children }: { children: ReactNode }) {
 export function SidebarTrigger() {
   const { setOpen } = useSidebar()
   return (
-    <button onClick={() => setOpen(o => !o)} className="p-2 md:hidden border rounded">
+    <button
+      onClick={() => setOpen(o => !o)}
+      className="p-2 border rounded hover:bg-gray-100"
+    >
       ☰
     </button>
   )


### PR DESCRIPTION
## Summary
- allow sidebar to collapse to a narrow width on desktop
- show sidebar toggle button on all screen sizes and add hover state

## Testing
- `bun run build.ts`

------
https://chatgpt.com/codex/tasks/task_e_68533a839cd0832fac6e66eebc1b6520