### PR TITLE
Fix header/sidebar layout clash

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -28,11 +28,11 @@ export function Sidebar({ children }: { children: ReactNode }) {
   const { open } = useSidebar()
   return (
     <aside
-      className={`fixed inset-y-0 left-0 z-40 w-64 bg-white border-r transform transition-transform flex flex-col ${
-        open ? 'translate-x-0' : '-translate-x-full'
+      className={`flex flex-col border-r bg-white overflow-hidden transition-[width] ${
+        open ? 'w-64' : 'w-0'
       }`}
     >
-      {children}
+      {open && children}
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- remove fixed positioning from sidebar so layout respects the header

## Testing
- `bun run build.ts --help`
- `bun run build.ts --outdir=dist` *(fails: Could not resolve "react-dom/client")*

------
https://chatgpt.com/codex/tasks/task_e_68539dec89f8832f83b3cd5dc33ec57e