### PR TITLE
Fix header height mismatch

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -21,7 +21,7 @@ export default function Layout({
         {session?.user && <AppSidebar />}
         <div className="flex-1 flex flex-col">
           {showHeader && session?.user && (
-            <header className="sticky top-0 z-50 flex h-14 shrink-0 items-center justify-between border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4">
+            <header className="sticky top-0 z-50 flex h-header shrink-0 items-center justify-between border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4">
               <div className="flex items-center gap-2">
                 <SidebarTrigger />
                 <span className="font-semibold">Bun App</span>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -38,7 +38,9 @@ export function Sidebar({ children }: { children: ReactNode }) {
 }
 
 export function SidebarHeader({ children }: { children: ReactNode }) {
-  return <div className="p-4 border-b flex items-center gap-2">{children}</div>
+  return (
+    <div className="h-header px-4 border-b flex items-center gap-2">{children}</div>
+  )
 }
 
 export function SidebarContent({ children }: { children: ReactNode }) {

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,7 @@
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --radius: 0.625rem;
+  --header-height: theme(spacing.14);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -65,6 +66,7 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  --header-height: theme(spacing.14);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,11 @@ module.exports = {
     './src/**/*.{ts,tsx,html}'
   ],
   theme: {
-    extend: {},
+    extend: {
+      height: {
+        header: 'var(--header-height)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add `--header-height` token in CSS
- extend Tailwind config to expose `h-header`
- use `h-header` for app and sidebar headers

## Testing
- `bun run build.ts --help`
- `bun run build.ts` *(fails: Could not resolve: "react-dom/client")*

------
https://chatgpt.com/codex/tasks/task_e_68539f3ed00c832f94e4908182991930