### PR TITLE
Enable local network access during development

### DIFF
--- a/src/lib/dev-origins.ts
+++ b/src/lib/dev-origins.ts
@@ -1,0 +1,12 @@
+export const devOriginPatterns = [
+  /^https?:\/\/localhost(?::\d{1,5})?$/,
+  /^https?:\/\/127(?:\.\d{1,3}){3}(?::\d{1,5})?$/,
+  /^https?:\/\/\[::1\](?::\d{1,5})?$/,
+  /^https?:\/\/10(?:\.\d{1,3}){3}(?::\d{1,5})?$/,
+  /^https?:\/\/172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2}(?::\d{1,5})?$/,
+  /^https?:\/\/192\.168(?:\.\d{1,3}){2}(?::\d{1,5})?$/,
+]
+
+export function isAllowedDevOrigin(origin: string) {
+  return devOriginPatterns.some(re => re.test(origin))
+}


### PR DESCRIPTION
## Summary
- allow private network origin patterns for development requests
- skip auth origin check when local origin matches

## Testing
- `bun run build.ts`


------
https://chatgpt.com/codex/tasks/task_e_6853a9fc808c832fb70a17a646795ed3