### PR TITLE
Refactor layout: header above sidebar

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -17,32 +17,32 @@ export default function Layout({
   const initial = session?.user?.email?.[0]?.toUpperCase() ?? ''
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex">
-        {session?.user && <AppSidebar />}
-        <div className="flex-1 flex flex-col">
-          {showHeader && session?.user && (
-            <header className="sticky top-0 z-50 flex h-14 shrink-0 items-center justify-between border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4">
-              <div className="flex items-center gap-2">
-                <SidebarTrigger />
-                <span className="font-semibold">Bun App</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="ghost" size="icon" className="rounded-full">
-                  {initial}
-                </Button>
-                <Button variant="ghost" size="icon">
-                  <Settings className="size-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setDark(v => !v)}
-                >
-                  {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
-                </Button>
-              </div>
-            </header>
-          )}
+      <div className="min-h-screen flex flex-col">
+        {showHeader && session?.user && (
+          <header className="sticky top-0 z-50 flex h-14 shrink-0 items-center justify-between border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4">
+            <div className="flex items-center gap-2">
+              <SidebarTrigger />
+              <span className="font-semibold">Bun App</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="icon" className="rounded-full">
+                {initial}
+              </Button>
+              <Button variant="ghost" size="icon">
+                <Settings className="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setDark(v => !v)}
+              >
+                {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+              </Button>
+            </div>
+          </header>
+        )}
+        <div className="flex flex-1">
+          {session?.user && <AppSidebar />}
           <main className="flex-1 p-4">{children}</main>
         </div>
       </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -28,7 +28,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
   const { open } = useSidebar()
   return (
     <aside
-      className={`flex flex-col border-r bg-white overflow-hidden transition-[width] ${
+      className={`flex h-full flex-col border-r bg-white overflow-hidden transition-[width] ${
         open ? 'w-64' : 'w-0'
       }`}
     >


### PR DESCRIPTION
## Summary
- restructure Layout so header spans full width above sidebar
- ensure sidebar fills remaining height

## Testing
- `bun run build.ts`

------
https://chatgpt.com/codex/tasks/task_e_6853b05eaf0c832fa384766d054b0234