### PR TITLE
Replace Dashboard with Lists

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,14 +1,57 @@
 import { authClient } from '../auth-client'
 import { Button } from './ui/button'
-import { Sidebar, SidebarContent, SidebarFooter } from './ui/sidebar'
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+} from './ui/sidebar'
+import { List, ChevronRight, ChevronDown } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export default function AppSidebar() {
   const { data: session } = authClient.useSession()
   if (!session?.user) return null
+  const COOKIE = 'lists_open'
+  const read = () => {
+    const c = document.cookie.split('; ').find(v => v.startsWith(COOKIE + '='))
+    return c ? c.split('=')[1] === 'true' : false
+  }
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    setOpen(read())
+  }, [])
+  useEffect(() => {
+    document.cookie = `${COOKIE}=${open}; path=/; max-age=${60 * 60 * 24 * 7}`
+  }, [open])
   return (
     <Sidebar>
       <SidebarContent>
-        <a href="/" className="block px-3 py-2 rounded hover:bg-muted">Dashboard</a>
+        <button
+          onClick={() => setOpen(v => !v)}
+          className="w-full flex items-center justify-between px-3 py-2 rounded hover:bg-muted"
+        >
+          <span className="flex items-center gap-2">
+            <List className="size-4" /> Lists
+          </span>
+          {open ? (
+            <ChevronDown className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          )}
+        </button>
+        {open && (
+          <div className="ml-6 mt-1 space-y-1 text-sm">
+            <a href="#" className="block px-3 py-1 rounded hover:bg-muted">
+              List 1
+            </a>
+            <a href="#" className="block px-3 py-1 rounded hover:bg-muted">
+              List 2
+            </a>
+            <a href="#" className="block px-3 py-1 rounded hover:bg-muted">
+              List 3
+            </a>
+          </div>
+        )}
         <a href="#" className="block px-3 py-2 rounded hover:bg-muted">Settings</a>
         <a href="#" className="block px-3 py-2 rounded hover:bg-muted">Help</a>
       </SidebarContent>


### PR DESCRIPTION
## Summary
- replace Dashboard link with an expandable Lists section
- show three placeholder list links
- persist Lists expansion state in a cookie

## Testing
- `bun run build.ts` *(fails: Could not resolve "react-dom/client" and "react/jsx-runtime")*

------
https://chatgpt.com/codex/tasks/task_e_685425363674832fbfc4ba52bf86e52d