### PR TITLE
Add invitation code registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ docker-compose up
 ```
 
 This will start the database and the Bun server.
+
+## Invitation Codes
+
+Generate a new code with:
+
+```bash
+bun run scripts/create-invite.ts
+```
+
+The generated code is valid for all new sign ups until you run the script again.

--- a/scripts/create-invite.ts
+++ b/scripts/create-invite.ts
@@ -1,0 +1,8 @@
+import { randomBytes } from 'crypto'
+import { db } from '../src/db'
+import { invitationCodes } from '../src/db/schema/auth-schema'
+
+const code = randomBytes(4).toString('hex')
+await db.delete(invitationCodes).execute()
+await db.insert(invitationCodes).values({ code }).execute()
+console.log(code)

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -2,16 +2,32 @@ import { useState } from 'react'
 import { Button } from './ui/button'
 import { authClient } from '../auth-client'
 
+async function requestLink(email: string, code: string) {
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, code })
+  })
+  if (!res.ok) throw new Error((await res.json()).error || 'Error')
+}
+
 export default function LoginForm() {
   const [email, setEmail] = useState('')
+  const [code, setCode] = useState('')
   const [loading, setLoading] = useState(false)
   const [sent, setSent] = useState(false)
+  const [error, setError] = useState('')
   const sendLink = async () => {
     if (!email) return
     setLoading(true)
-    await authClient.signIn.magicLink({ email })
+    setError('')
+    try {
+      await requestLink(email, code)
+      setSent(true)
+    } catch (e: any) {
+      setError(e.message)
+    }
     setLoading(false)
-    setSent(true)
   }
   if (sent) return <p className="p-2">Check your email to log in.</p>
   return (
@@ -22,6 +38,13 @@ export default function LoginForm() {
         onChange={e => setEmail(e.target.value)}
         placeholder="Email"
       />
+      <input
+        className="border p-2 w-full"
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        placeholder="Invitation Code"
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
       <Button onClick={sendLink} disabled={loading}>
         {loading ? 'Sending...' : 'Send Magic Link'}
       </Button>

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -44,4 +44,9 @@ export const verifications = pgTable("verifications", {
  expiresAt: timestamp('expires_at').notNull(),
  createdAt: timestamp('created_at').$defaultFn(() => new Date),
  updatedAt: timestamp('updated_at').$defaultFn(() => new Date)
-				});
+                               });
+
+export const invitationCodes = pgTable("invitation_codes", {
+                                        code: text('code').primaryKey(),
+                                        createdAt: timestamp('created_at').$defaultFn(() => new Date)
+                                });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,27 @@
 import { serve } from "bun";
 import index from "./index.html";
 import { auth } from "./auth";
+import { db } from './db'
+import { users, invitationCodes } from './db/schema/auth-schema'
+import { eq } from 'drizzle-orm'
 
 const server = serve({
   routes: {
     "/api/auth/*": auth.handler,
+    "/api/register": async req => {
+      if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 })
+      const { email, code } = await req.json()
+      if (!email) return Response.json({ error: 'Email required' }, { status: 400 })
+      const existing = (await db.select().from(users).where(eq(users.email, email))).at(0)
+      if (!existing) {
+        const invite = (await db.select().from(invitationCodes)).at(0)
+        if (!invite || invite.code !== code) {
+          return Response.json({ error: 'Invalid invitation code' }, { status: 400 })
+        }
+      }
+      await auth.signIn.magicLink({ email })
+      return Response.json({ ok: true })
+    },
 
     // Serve index.html for all unmatched routes.
     "/*": index,


### PR DESCRIPTION
## Summary
- require invitation code for new signups
- one code at a time, reusable until replaced by script
- update script and docs for new flow

## Testing
- `bun run build.ts` *(fails: Cannot find package 'bun-plugin-tailwind')*

------
https://chatgpt.com/codex/tasks/task_e_685e59f46a70832fb6cef75155598029