### PR TITLE
Fix magic link call

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ const server = serve({
           return Response.json({ error: 'Invalid invitation code' }, { status: 400 })
         }
       }
-      await auth.signIn.magicLink({ email })
+      await auth.magicLink.signIn({ email })
       return Response.json({ ok: true })
     },
 


### PR DESCRIPTION
## Summary
- fix calling Better Auth magic link on registration

## Testing
- `bun run build.ts --outdir temp_build` *(fails: Cannot find package 'bun-plugin-tailwind')*

------
https://chatgpt.com/codex/tasks/task_e_685e5e69e3e4832f9a235e17edd5e575